### PR TITLE
Point the main to the cjs built location

### DIFF
--- a/packages/remark-wrap-in-section/package.json
+++ b/packages/remark-wrap-in-section/package.json
@@ -2,7 +2,7 @@
   "name": "@tufte-markdown/remark-wrap-in-section",
   "version": "1.0.0",
   "description": "A remark transformer wrapping document blocks that are started by a level-2 heading in a section to support html that relies on the stylesheets of Edward Tufte",
-  "main": "dist/remark-wrap-in-section.js",
+  "main": "dist/remark-wrap-in-section.cjs.js",
   "module": "dist/remark-wrap-in-section.es.js",
   "scripts": {
     "preversion": "npm run build",


### PR DESCRIPTION
Thanks for the great library! 

Unfortunately the wrap-in-section package is specifying an incorrect main. Based on the build this should fix it.